### PR TITLE
docs(agents): clarify direct push rule wording

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Static genealogy site (family tree). Indonesian language. Pages: `tree.html` (ma
 
 ## Rules
 - **Clarify before acting**: when given a task, present findings + proposed scope first. Ask if unclear. Don't assume or over-engineer.
-- **Always create PR/MR** for every change, unless explicitly told "push to main" or "push directly".
+- **Always create PR/MR** for every change. Direct push to `main` only when exact phrase **"push to main"** or **"push directly"** appears in user instruction. "commit push git" or "push" alone do NOT qualify.
 - **When switching to `main`**: always run `git pull --ff-only` first to keep local up to date.
 
 ## Phase status


### PR DESCRIPTION
Make PR rule unambiguous: 'commit push git' and 'push' alone do NOT qualify for direct push. Only exact phrases 'push to main' or 'push directly' trigger direct push.