### PR TITLE
fix(attendance): clear global trah_auth cookie on logout

### DIFF
--- a/attendance.html
+++ b/attendance.html
@@ -669,6 +669,7 @@
       document.querySelectorAll('.admin-only').forEach(function(el){ el.classList.add('visible'); });
       updateAdminBtnUI(true);
       setCookie('trah_attendance_admin', 'admin', 30);
+      setCookie('trah_auth', 'admin', 30);
     }
     function logoutAdmin() {
       isAdmin = false;
@@ -677,6 +678,7 @@
       document.querySelectorAll('.admin-only').forEach(function(el){ el.classList.remove('visible'); });
       updateAdminBtnUI(false);
       setCookie('trah_attendance_admin', '', -1);
+      setCookie('trah_auth', 'guest', 30);
       renderAdminEvents();
     }
     function updateAdminBtnUI(active) {


### PR DESCRIPTION
## Problem

`logoutAdmin()` on `attendance.html` only cleared the local `trah_attendance_admin` cookie but never touched the global `trah_auth` cookie. Other pages (`tree.html`, `request-list.html`) read `trah_auth` to determine admin state — so admin persisted everywhere after logging out from attendance.

## Fix

- `logoutAdmin()`: added `setCookie('trah_auth', 'guest', 30)` — matches `tree.html` pattern
- `applyAdminMode()`: added `setCookie('trah_auth', 'admin', 30)` — so attendance login propagates globally

Closes logout state leak across pages.