### PR TITLE
feat(dashboard): add slot-text animation to stat counters

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -14,6 +14,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/menu.css">
   <link rel="stylesheet" href="css/cursor.css">
+  <link rel="stylesheet" href="https://unpkg.com/slot-text/style.css">
   <style>
     :root {
       --gold: #b8822e; --gold-light: #d4a55a; --gold-dim: rgba(184,130,46,0.12);
@@ -390,7 +391,9 @@
   </main>
 
   <script src="js/config.local.js"></script>
-  <script>
+  <script type="module">
+  import { slotText } from 'https://esm.sh/slot-text';
+
   (function() {
     'use strict';
 
@@ -400,8 +403,6 @@
     function supaHeaders() {
       return { 'Content-Type': 'application/json', 'apikey': SUPABASE_KEY, 'Authorization': 'Bearer ' + SUPABASE_KEY };
     }
-
-    function $(id) { return document.getElementById(id); }
 
     function fetchStats() {
       var totalMembers = fetch(SUPABASE_URL + '/rest/v1/members?select=id&deleted_at=is.null', { headers: supaHeaders() })
@@ -441,39 +442,45 @@
       return Promise.all([totalMembers, totalSpouses, genP, genderMembers, genderSpouses]);
     }
 
+    var slots = {};
+
     function renderStats(total, generasi, gender) {
-      var el = $('statTotal');
-      if (el) { el.textContent = total || 0; el.classList.remove('loading'); }
-
-      el = $('statGenerasi');
-      if (el) { el.textContent = generasi || 0; el.classList.remove('loading'); }
-
-      el = $('statLaki');
-      if (el) { el.textContent = gender.laki || 0; el.classList.remove('loading'); }
-
-      el = $('statPerempuan');
-      if (el) { el.textContent = gender.perempuan || 0; el.classList.remove('loading'); }
-    }
-
-    function showStatsError() {
+      slots.total.set(String(total || 0));
+      slots.generasi.set(String(generasi || 0));
+      slots.laki.set(String(gender.laki || 0));
+      slots.perempuan.set(String(gender.perempuan || 0));
       ['statTotal','statGenerasi','statLaki','statPerempuan'].forEach(function(id) {
-        var el = $(id);
-        if (el) { el.textContent = '—'; el.classList.remove('loading'); }
+        var el = document.getElementById(id);
+        if (el) el.classList.remove('loading');
       });
     }
 
-    document.addEventListener('DOMContentLoaded', function() {
-      fetchStats()
-        .then(function(results) {
-          var total = results[0] + results[1];
-          var generasi = results[2];
-          var gender = { laki: results[3].laki + results[4].laki, perempuan: results[3].perempuan + results[4].perempuan };
-          renderStats(total, generasi, gender);
-        })
-        .catch(function() {
-          showStatsError();
-        });
-    });
+    function showStatsError() {
+      slots.total.set('—');
+      slots.generasi.set('—');
+      slots.laki.set('—');
+      slots.perempuan.set('—');
+      ['statTotal','statGenerasi','statLaki','statPerempuan'].forEach(function(id) {
+        var el = document.getElementById(id);
+        if (el) el.classList.remove('loading');
+      });
+    }
+
+    slots.total     = slotText(document.getElementById('statTotal'),     '—');
+    slots.generasi  = slotText(document.getElementById('statGenerasi'),  '—');
+    slots.laki      = slotText(document.getElementById('statLaki'),      '—');
+    slots.perempuan = slotText(document.getElementById('statPerempuan'), '—');
+
+    fetchStats()
+      .then(function(results) {
+        var total = results[0] + results[1];
+        var generasi = results[2];
+        var gender = { laki: results[3].laki + results[4].laki, perempuan: results[3].perempuan + results[4].perempuan };
+        renderStats(total, generasi, gender);
+      })
+      .catch(function() {
+        showStatsError();
+      });
 
   })();
   </script>


### PR DESCRIPTION
## Summary
- Add `slot-text` animation (via `esm.sh` CDN) to the 4 dashboard stat counters: Total Anggota, Generasi, Laki-laki, Perempuan
- Numbers animate from `—` into real values once Supabase fetch completes
- Fixed: original `unpkg` import served CJS instead of ESM, causing the entire module script to silently abort — switched to `esm.sh` which always serves proper ES modules
- Removed `DOMContentLoaded` wrapper (redundant for end-of-body module scripts)

## Test plan
- [ ] Load dashboard in browser — stat cards should show `—` initially
- [ ] After Supabase responds, numbers should slot-animate into actual counts
- [ ] Refresh to confirm the animation plays every time
- [ ] Confirm no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)