### PR TITLE
fix(cursor): lower inner dot opacity for readability

### DIFF
--- a/css/cursor.css
+++ b/css/cursor.css
@@ -19,13 +19,13 @@
 }
 
 .cursor-dot.is-visible {
-  opacity: 1;
+  opacity: 0.45;
 }
 
 .cursor-dot.is-hover {
   width: 40px;
   height: 40px;
-  opacity: 0.5;
+  opacity: 0.3;
 }
 
 /* ── Trailing ring (slow follower) ── */


### PR DESCRIPTION
## Summary
Make the filled cursor dot semi-transparent so text and elements behind it remain readable.

- Default (`.cursor-dot.is-visible`): opacity `1` → `0.45`
- Hover (`.cursor-dot.is-hover`): opacity `0.5` → `0.3`

The trailing `.cursor-ring` was already transparent (border-only), so no change there. The dot keeps `mix-blend-mode: difference` for contrast.

## Test plan
- Open any `.html` page directly in the browser and move the cursor over text/links to confirm content behind the dot stays readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)